### PR TITLE
Fix oveflow in the display of emote sets caused by narrow emotes

### DIFF
--- a/src/assets/scss/components/emote-set-card.scss
+++ b/src/assets/scss/components/emote-set-card.scss
@@ -46,9 +46,10 @@
 			> img {
 				margin: 0.25em;
 				transform: translateZ(0);
-				height: auto;
+				height: 100%;
 				image-rendering: pixelated;
-				width: calc((100% / 6) - 0.25em);
+				max-width: calc((100% / 6) - 0.25em);
+				object-fit: contain;
 			}
 		}
 


### PR DESCRIPTION
An example of this can be seen [here](https://7tv.dev/users/61390d6af7977b64f644b941).