### PR TITLE
Allign paints in grid

### DIFF
--- a/src/views/Store/SubStatus.vue
+++ b/src/views/Store/SubStatus.vue
@@ -344,6 +344,8 @@ main.sub-status {
 				> div.paint-list {
 					padding: 0.25em;
 					font-size: 1.25em;
+					display: grid;
+					grid-template-columns: repeat(auto-fit, 8em);
 				}
 			}
 		}


### PR DESCRIPTION
Alligns the paints in the sub page in a grid 
<img width="1047" alt="Screenshot 2022-08-13 at 18 11 51" src="https://user-images.githubusercontent.com/49245223/184502168-63ff07c6-1f44-4f24-82ab-5889dd1fe739.png">
