### PR TITLE
fix: background disappearing without animation

### DIFF
--- a/src/assets/scss/nav.scss
+++ b/src/assets/scss/nav.scss
@@ -31,9 +31,9 @@ nav {
 				opacity: 0;
 				background-size: 0.25vw 0.25vh;
 				backdrop-filter: blur(0.25em) brightness(100%);
+				background-color: transparentize(themed("navBackgroundColor"), 0.8);
 				&.highlight {
 					opacity: 1;
-					background-color: transparentize(themed("navBackgroundColor"), 0.8);
 				}
 			}
 			&[transparent="true"]:hover,


### PR DESCRIPTION
When scrolling back up on the home page, the background of the navbar disappears without an animation.