### PR TITLE
refactor: image loading

### DIFF
--- a/src/components/utility/EmoteCard.vue
+++ b/src/components/utility/EmoteCard.vue
@@ -227,6 +227,9 @@ const emote = computed(() => props.emote);
 watch(
 	emote,
 	(e) => {
+		if (unload.value) {
+			return;
+		}
 		imageURL.value = Emote.GetImage(e.images, Common.Image.Format.WEBP, "3x")?.url as string;
 		imageLoadError.value = false;
 	},

--- a/src/components/utility/EmoteCard.vue
+++ b/src/components/utility/EmoteCard.vue
@@ -16,7 +16,12 @@
 				@contextmenu="openContext"
 			>
 				<div class="img-wrapper" :censor="!emote.listed && !actor.hasPermission(Permissions.EditAnyEmote)">
-					<img v-if="!isUnavailable" :src="imageURL" />
+					<img
+						v-if="!isUnavailable && !imageLoadError"
+						decoding="async"
+						:src="imageURL"
+						@error="onLoadError"
+					/>
 					<img v-else src="@img/question.webp" />
 				</div>
 				<div class="img-gap" />
@@ -217,26 +222,19 @@ const openContext = (ev: MouseEvent) => {
 
 const unload = computed(() => props.unload);
 const imageURL = ref("");
+const imageLoadError = ref(false);
 const emote = computed(() => props.emote);
-let img: HTMLImageElement | null;
 watch(
 	emote,
 	(e) => {
-		imageURL.value = "";
-		if (img) {
-			img.src = "";
-		}
-		if (unload.value) {
-			return;
-		}
-		img = new Image();
-		img.onload = () => {
-			imageURL.value = (img as HTMLImageElement).src as string;
-		};
-		img.src = Emote.GetImage(e.images, Common.Image.Format.WEBP, "3x")?.url as string;
+		imageURL.value = Emote.GetImage(e.images, Common.Image.Format.WEBP, "3x")?.url as string;
+		imageLoadError.value = false;
 	},
 	{ immediate: true },
 );
+const onLoadError = () => {
+	imageLoadError.value = true;
+};
 
 watch(
 	unload,


### PR DESCRIPTION
Currently emote images are loaded indirectly through the creation of an `Image`, however there seems to be no need to use this indirection (also images without a `src` display an ugly box in Firefox).

With this PR, the browser can decide when it wants to load an image. This doesn't block the rendering (`decoding=async`). It even catches errors when the image cannot be loaded.