### PR TITLE
fix: pad user's owned emotes section

### DIFF
--- a/src/views/UserPage/UserPage.vue
+++ b/src/views/UserPage/UserPage.vue
@@ -74,16 +74,18 @@
 							/>
 						</span>
 					</h3>
-					<div v-if="user" class="owned-emotes emote-list">
-						<EmoteCard v-for="emote of pagedOwnedEmotes" :key="emote.id" :emote="emote" />
-					</div>
-					<div v-if="ownedPager.length / ownedPager.pageSize > 1">
-						<Paginator
-							:page="ownedPager.page"
-							:items-per-page="ownedPager.pageSize"
-							:length="ownedPager.length"
-							@change="(change) => (ownedPager.page = change.page)"
-						/>
+					<div v-if="user" section-body>
+						<div class="owned-emotes emote-list">
+							<EmoteCard v-for="emote of pagedOwnedEmotes" :key="emote.id" :emote="emote" />
+						</div>
+						<div v-if="ownedPager.length / ownedPager.pageSize > 1">
+							<Paginator
+								:page="ownedPager.page"
+								:items-per-page="ownedPager.pageSize"
+								:length="ownedPager.length"
+								@change="(change) => (ownedPager.page = change.page)"
+							/>
+						</div>
 					</div>
 
 					<!-- Display Activity -->


### PR DESCRIPTION
This PR aims to fix an issue where the padding of a user's "Owned emotes" section was inconsistent with the previous "Channel emotes" section. This appears to be caused by a difference in how the sections are laid out.

Current layout as of 54066ff (ignore Firefox's SS tool adding the navbar to the middle)
![image](https://user-images.githubusercontent.com/4962764/187064775-81313683-acd6-452e-8eb6-791b3ce2a56e.png)

---

Off-topic: I thought this would be a simple "clone & commit" deal, but I have to say the developer experience of getting this solution running has been a bit painful. The reliance on font-awesome pro packages  breaks both the install and dev serer. It would be great if either this dependency was removed or a `CONTRIBUTING` guide was added explaining how to set this up. 

I was also unable to test this locally as it appears to need an auth server running locally? No documentation so have no idea how to test that.

Thanks @Nerixyz for sending me a patch just to get this working.