### PR TITLE
Main nav accessibility improvements

### DIFF
--- a/locale/en_US.ts
+++ b/locale/en_US.ts
@@ -92,6 +92,9 @@ export default {
 		sign_in: "Sign In",
 		user_search: "Search Profiles",
 		locale_contribute: "Translate @:common.appName{'!'}",
+		locale_select: "Select locale",
+		inbox: "Inbox",
+		theme: "Switch theme",
 
 		wip_notice: {
 			heading: "Welcome to the new @:common.appName website",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"no-darkreader": "^1.0.3",
 		"pinia": "^2.0.20",
 		"set-value": "^4.1.0",
+		"short-uuid": "^4.2.0",
 		"subscriptions-transport-ws": "^0.11.0",
 		"ua-parser-js": "^1.0.2",
 		"v-wave": "^1.5.0",

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -25,7 +25,13 @@
 			<div class="account">
 				<!-- User Search -->
 				<Tooltip :text="t('nav.user_search')" position="bottom">
-					<div class="nav-button" @click="userSearch = !userSearch">
+					<div
+						class="nav-button"
+						tabindex="0"
+						role="button"
+						aria-haspopup="listbox"
+						@click="userSearch = !userSearch"
+					>
 						<UserSearchIcon />
 					</div>
 				</Tooltip>
@@ -34,21 +40,27 @@
 				<div class="separator" />
 
 				<!-- Locale -->
-				<LocaleSelector />
+				<Tooltip :text="t('nav.locale_select')" position="bottom">
+					<LocaleSelector />
+				</Tooltip>
 
 				<!-- Inbox Button -->
-				<router-link v-if="actor.user" class="unstyled-link" to="/inbox">
-					<div class="nav-button inbox">
-						<Icon icon="envelope" />
-						<div v-if="actor.user.inbox_unread_count > 0" class="inbox-counter">
-							<div>{{ actor.user.inbox_unread_count }}</div>
+				<Tooltip :text="t('nav.inbox')" position="bottom">
+					<router-link v-if="actor.user" class="unstyled-link" to="/inbox">
+						<div class="nav-button">
+							<Icon icon="envelope" />
+							<div v-if="actor.user.inbox_unread_count > 0" class="inbox-counter">
+								<div>{{ actor.user.inbox_unread_count }}</div>
+							</div>
 						</div>
-					</div>
-				</router-link>
+					</router-link>
+				</Tooltip>
 
-				<div class="nav-button theme">
-					<ThemeSwitcher />
-				</div>
+				<Tooltip :text="t('nav.theme')" position="bottom">
+					<div class="nav-button theme" tabindex="0" role="button">
+						<ThemeSwitcher />
+					</div>
+				</Tooltip>
 
 				<div v-if="actor.user === null" class="twitch-button">
 					<LoginButton />

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -24,12 +24,13 @@
 			</div>
 			<div class="account">
 				<!-- User Search -->
-				<Tooltip :text="t('nav.user_search')" position="bottom">
+				<Tooltip v-slot="{ labelId }" :text="t('nav.user_search')" position="bottom">
 					<div
 						class="nav-button"
-						tabindex="0"
 						role="button"
 						aria-haspopup="listbox"
+						:aria-labelledby="labelId"
+						tabindex="0"
 						@click="userSearch = !userSearch"
 					>
 						<UserSearchIcon />
@@ -40,13 +41,20 @@
 				<div class="separator" />
 
 				<!-- Locale -->
-				<Tooltip :text="t('nav.locale_select')" position="bottom">
-					<LocaleSelector />
+				<Tooltip v-slot="{ labelId }" :text="t('nav.locale_select')" position="bottom">
+					<LocaleSelector :label-id="labelId" />
 				</Tooltip>
 
 				<!-- Inbox Button -->
-				<Tooltip :text="t('nav.inbox')" position="bottom">
-					<router-link v-if="actor.user" class="unstyled-link" to="/inbox">
+				<Tooltip v-slot="{ labelId }" :text="t('nav.inbox')" position="bottom">
+					<router-link
+						v-if="actor.user"
+						class="unstyled-link"
+						to="/inbox"
+						role="button"
+						:aria-labelledby="labelId"
+						tabindex="0"
+					>
 						<div class="nav-button">
 							<Icon icon="envelope" />
 							<div v-if="actor.user.inbox_unread_count > 0" class="inbox-counter">
@@ -56,9 +64,9 @@
 					</router-link>
 				</Tooltip>
 
-				<Tooltip :text="t('nav.theme')" position="bottom">
-					<div class="nav-button theme" tabindex="0" role="button">
-						<ThemeSwitcher />
+				<Tooltip v-slot="{ labelId }" :text="t('nav.theme')" position="bottom">
+					<div class="nav-button theme">
+						<ThemeSwitcher :label-id="labelId" />
 					</div>
 				</Tooltip>
 

--- a/src/components/form/TextInput.vue
+++ b/src/components/form/TextInput.vue
@@ -1,6 +1,7 @@
 <template>
 	<div class="text-input" :appearance="appearance">
 		<input
+			:id="inputUuid"
 			ref="inputEl"
 			:type="type"
 			:error="error"
@@ -10,7 +11,7 @@
 			@input="onInput"
 			@blur="emit('blur')"
 		/>
-		<label class="input-name">
+		<label :for="inputUuid" class="input-name">
 			<Icon v-if="icon" :icon="icon" />
 			<span> {{ label }} </span>
 		</label>
@@ -26,6 +27,7 @@
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
 import Icon from "../utility/Icon.vue";
+import uuidv4 from "short-uuid";
 
 const props = withDefaults(
 	defineProps<{
@@ -44,6 +46,7 @@ const props = withDefaults(
 	},
 );
 
+const inputUuid = "input_" + uuidv4.generate();
 const emit = defineEmits(["update:modelValue", "blur"]);
 const onInput = (event: Event) => emit("update:modelValue", (event.target as HTMLInputElement).value);
 

--- a/src/components/utility/LocaleSelector.vue
+++ b/src/components/utility/LocaleSelector.vue
@@ -1,24 +1,31 @@
 <template>
 	<div class="locale-switcher" data-locale-switcher>
 		<!-- Currently selected language -->
-		<div v-if="current" class="current-locale" @click="open = !open">
+		<div
+			v-if="current"
+			class="current-locale"
+			aria-haspopup="listbox"
+			role="button"
+			tabindex="0"
+			@click="open = !open"
+		>
 			<Icon icon="language" />
 		</div>
-
-		<div v-if="open" class="locale-dropdown">
+		<div v-if="open" class="locale-dropdown" role="listbox">
 			<div class="contribute-cta">
 				<a href="https://crowdin.com/project/7tv" target="_blank">
 					{{ t("nav.locale_contribute") }}
 				</a>
 				<AnnotatedBadge :badge="translatorBadge" size="1.25rem" :hide-name="true" />
 			</div>
-
 			<div class="locale-list">
 				<div
 					v-for="locale of icons"
 					:key="locale.key"
 					:locale="locale.name"
 					:selected="locale.key === current.key"
+					aria-role="option"
+					tabindex="0"
 					@click="() => setLocale(locale?.key)"
 				>
 					<component :is="locale.icon" />

--- a/src/components/utility/LocaleSelector.vue
+++ b/src/components/utility/LocaleSelector.vue
@@ -7,6 +7,7 @@
 			aria-haspopup="listbox"
 			role="button"
 			tabindex="0"
+			:aria-labelledby="labelId"
 			@click="open = !open"
 		>
 			<Icon icon="language" />
@@ -53,6 +54,13 @@ const open = ref(false);
 
 const { t } = useI18n();
 const translatorBadge = badgeDefs.find((b) => b.id === "translator") as BadgeDef;
+
+defineProps({
+	labelId: {
+		type: String,
+		default: "",
+	},
+});
 
 const mdListener = (evt: MouseEvent) => {
 	if (!open.value) {

--- a/src/components/utility/ThemeSwitcher.vue
+++ b/src/components/utility/ThemeSwitcher.vue
@@ -1,9 +1,23 @@
 <template>
 	<div class="theme-switcher">
 		<div class="" />
-
-		<Icon v-if="theme === 'dark'" class="unselectable" icon="sun-bright" @click="() => changeTheme('light')" />
-		<Icon v-else class="unselectable" icon="moon" @click="() => changeTheme('dark')" />
+		<Icon
+			v-if="theme === 'dark'"
+			class="unselectable"
+			icon="sun-bright"
+			role="button"
+			:aria-labelledby="labelId"
+			tabindex="0"
+			@click="() => changeTheme('light')" role="button"
+		/>
+		<Icon
+			v-else class="unselectable"
+			icon="moon"
+			role="button"
+			:aria-labelledby="labelId"
+			tabindex="0"
+			@click="() => changeTheme('dark')"
+		/>
 	</div>
 </template>
 
@@ -19,4 +33,11 @@ const theme = computed(() => store.getTheme as "light" | "dark");
 const changeTheme = (theme: "dark" | "light") => {
 	store.setTheme(theme);
 };
+
+defineProps({
+	labelId: {
+		type: String,
+		default: "",
+	},
+});
 </script>

--- a/src/components/utility/Tooltip.vue
+++ b/src/components/utility/Tooltip.vue
@@ -1,11 +1,9 @@
 <template>
 	<Popper :hover="true" :placement="position">
-		<div :aria-labelledby="uuid">
-			<slot />
-		</div>
+		<slot :label-id="uuid" />
 		<template #content>
-			<div ref="tooltip" class="tooltip">
-				<span :id="uuid">{{ text }}</span>
+			<div :id="uuid" ref="tooltip" class="tooltip" role="tooltip">
+				<span>{{ text }}</span>
 			</div>
 		</template>
 	</Popper>

--- a/src/components/utility/Tooltip.vue
+++ b/src/components/utility/Tooltip.vue
@@ -1,9 +1,11 @@
 <template>
 	<Popper :hover="true" :placement="position">
-		<slot />
+		<div :aria-labelledby="uuid">
+			<slot />
+		</div>
 		<template #content>
 			<div ref="tooltip" class="tooltip">
-				<span>{{ text }}</span>
+				<span :id="uuid">{{ text }}</span>
 			</div>
 		</template>
 	</Popper>
@@ -12,6 +14,7 @@
 <script setup lang="ts">
 import type { Placement } from "@popperjs/core";
 import { PropType } from "vue";
+import uuidv4 from "short-uuid";
 
 defineProps({
 	text: {
@@ -26,6 +29,8 @@ defineProps({
 		default: "auto",
 	},
 });
+
+const uuid = "tooltip_" + uuidv4.generate();
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/utility/UserQuickSearch.vue
+++ b/src/components/utility/UserQuickSearch.vue
@@ -2,12 +2,11 @@
 	<main ref="mainEl" class="user-quick-search">
 		<TextInput v-model="arg" :label="t('nav.user_search')" :autofocus="true" @keyup.enter="useExactResult" />
 
-		<div v-if="users.length && !eventOnly" class="result-tray">
+		<div v-if="users.length && !eventOnly" class="result-tray" aria-role="listbox">
 			<router-link
-				v-for="(user, index) of users"
+				v-for="user of users"
 				:key="user.id"
-				:aria-colindex="index"
-				:aria-colcount="users.length"
+				aria-role="option"
 				:to="{ name: 'User', params: { userID: user.id, userData: JSON.stringify(user) } }"
 				class="user-result unstyled-link"
 				@click.prevent="dismiss"
@@ -15,12 +14,11 @@
 				<UserTag scale="1.5em" text-scale="0.85rem" :user="user" />
 			</router-link>
 		</div>
-		<div v-else-if="users.length" class="result-tray">
+		<div v-else-if="users.length" class="result-tray" aria-role="listbox">
 			<span
-				v-for="(user, index) of users"
+				v-for="user of users"
 				:key="user.id"
-				:aria-colindex="index"
-				:aria-colcount="users.length"
+				aria-role="option"
 				class="user-result"
 				@click="emit('select', user)"
 				@click.prevent="dismiss"


### PR DESCRIPTION
Improves the accessibility of the main nav.

- Basic keyboard navigation
- Screen reader-friendly labeling

The Tooltip component now passes its generated unique label for use by any child element that needs to attach it (e.g., for `aria-labelledby`).

Ideally, the entire header nav needs to be restructured to make better use of semantic HTML and to standardize button structure, but I didn't want to interfere with any styling for this PR.