### PR TITLE
Pluralize `no_channel_emotes` for when a user does not have any 7TV emotes

### DIFF
--- a/locale/en_US.ts
+++ b/locale/en_US.ts
@@ -286,7 +286,7 @@ export default {
 		editor_modal_heading: "Modify {0}'s Editors",
 		editor_modal_user_search: "Who would you like to add as an editor?",
 		editor_modal_user_update: "Editor",
-		no_channel_emotes: "{0} does not have any emote on their {1} channel",
+		no_channel_emotes: "{0} does not have any emotes on their {1} channel",
 		no_channels: "{0} doesn't have any channels connected!",
 		card: {
 			view_full_profile: "View Full Profile",


### PR DESCRIPTION
Noticed while looking at an issue a user was having a problem with their own channel emotes not loading, and making sure said issue was not chatterino7 related.

Discussed in chat that updating only en_US will notify crowdin translators that a string needs to be updated.