### PR TITLE
fix: DedicatedWorker fallback for mobile devices

### DIFF
--- a/src/worker/DedicatedWorker.ts
+++ b/src/worker/DedicatedWorker.ts
@@ -1,0 +1,7 @@
+import { handleMessage, target } from "./Worker";
+
+const dw = self as unknown as DedicatedWorkerGlobalScope;
+
+dw.addEventListener("message", handleMessage);
+
+target.bc = new BroadcastChannel("WorkerEvents");

--- a/src/worker/SharedWorker.ts
+++ b/src/worker/SharedWorker.ts
@@ -1,0 +1,14 @@
+import { handleMessage, target } from "./Worker";
+
+const sw = self as unknown as SharedWorkerGlobalScope;
+
+sw.addEventListener("connect", (evt) => {
+	const port = evt.ports[0];
+	target.ports.push(port);
+
+	port.start();
+
+	port.addEventListener("message", handleMessage);
+});
+
+target.shared = true;


### PR DESCRIPTION
Shared Web Workers are not supported on some mobile browsers. This adds functionality to fall back to a regular dedicated worker.

This does not add compatibility for browsers that have no support for web workers at all, but will prevent a total crash.