### PR TITLE
apollo: omit `Authorization` header

### DIFF
--- a/src/apollo/apollo.ts
+++ b/src/apollo/apollo.ts
@@ -1,4 +1,3 @@
-import { LocalStorageKeys } from "@store/lskeys";
 import { ApolloClient, ApolloLink, InMemoryCache, createHttpLink } from "@apollo/client/core";
 
 // HTTP connection to the API
@@ -8,21 +7,11 @@ const httpLink = createHttpLink({
 	credentials: "include",
 });
 
-// Set up auth
-const authLink = new ApolloLink((op, next) => {
-	const tkn = localStorage.getItem(LocalStorageKeys.TOKEN);
-
-	if (tkn) {
-		op.setContext({
-			headers: {
-				Authorization: `Bearer ${tkn}`,
-			},
-		});
-	}
+const mid = new ApolloLink((op, next) => {
 	return next(op);
 });
 
-const link = ApolloLink.from([authLink, httpLink]);
+const link = ApolloLink.from([mid, httpLink]);
 
 // Cache implementation
 const cache = new InMemoryCache({


### PR DESCRIPTION
Removing the `Authorization` header from being used on the website, this will have the effect of signing out all users who have not recently logged in, compelling re-authentication. This is necessary as auth has moved to cookies and some features such as account linking fails without a cookie.