### PR TITLE
Disable stable download on firefox

### DIFF
--- a/src/composables/useDownloadLink.ts
+++ b/src/composables/useDownloadLink.ts
@@ -2,7 +2,7 @@ import { toRef } from "vue";
 
 const data = {
 	chromium: "https://chrome.google.com/webstore/detail/7tv/ammjkodgmmoknidbanneddgankgfejfh",
-	firefox: "https://addons.mozilla.org/en-US/firefox/addon/7tv",
+	firefox: "", // gone for now because mozilla is stupid
 	chromium_beta: "https://chrome.google.com/webstore/detail/7tv-nightly/fphegifdehlodcepfkgofelcenelpedj",
 	firefox_beta: "https://addons.mozilla.org/en-US/firefox/addon/7tv-nightly/",
 


### PR DESCRIPTION
Disabling the download for stable, since the current version is super outdated after mozilla decided to review a completely different extension and then block our updates because of it. 