### PR TITLE
Add Firefox as supported browser for AVIF

### DIFF
--- a/src/store/actor.ts
+++ b/src/store/actor.ts
@@ -59,7 +59,7 @@ export const useActor = defineStore("actor", {
 		avifSupported(): boolean {
 			const version = parseInt(this.browser.version as string, 10);
 			switch(this.browser.name) {
-				case "Chrome":  return version >= 85;
+				case "Chrome":  return version >= 100;
 				case "Firefox": return version >= 113;
 				default:        return false;
 			}

--- a/src/store/actor.ts
+++ b/src/store/actor.ts
@@ -57,7 +57,12 @@ export const useActor = defineStore("actor", {
 			return this.agent.getBrowser();
 		},
 		avifSupported(): boolean {
-			return this.browser.name === "Chrome" && parseInt(this.browser.version as string, 10) >= 100;
+			const version = parseInt(this.browser.version as string, 10);
+			switch(this.browser.name) {
+				case "Chrome":  return version >= 85;
+				case "Firefox": return version >= 113;
+				default:        return false;
+			}
 		},
 	},
 	actions: {


### PR DESCRIPTION
Since Firefox 113 finally enables animated avif by default it should be reflected in the front end. Even if no one should use such an old version, just for correctness the actual Chrome version that introduced full avif support was 85.