### PR TITLE
Fix to prevent deletion of personal emote set

### DIFF
--- a/src/views/emote-set/EmoteSetPage.vue
+++ b/src/views/emote-set/EmoteSetPage.vue
@@ -21,7 +21,7 @@
 							<Icon icon="pen" />
 						</div>
 
-						<div v-if="editable" v-wave class="action-button" name="delete" @click="promptDelete">
+						<div v-if="editable && !isPersonal" v-wave class="action-button" name="delete" @click="promptDelete">
 							<Icon icon="trash" />
 						</div>
 					</div>


### PR DESCRIPTION
Added !isPersonal to the conditional rendering of the delete button, this should be a temporary fix to stop users from deleting their personal emote set.

Related to: #979 

![](https://cdn.7tv.app/emote/63c1eb29e2d16742d3c990a9/4x.png)