### PR TITLE
emote-card: Uncensor unlisted emote via indicator click

### DIFF
--- a/src/components/utility/EmoteCard.vue
+++ b/src/components/utility/EmoteCard.vue
@@ -14,7 +14,9 @@
 		>
 			<div
 				class="img-wrapper"
-				:censor="!emote.state.includes('LISTED') && !actor.hasPermission(Permissions.EditAnyEmote)"
+				:censor="
+					!forceUncensor && !emote.state.includes('LISTED') && !actor.hasPermission(Permissions.EditAnyEmote)
+				"
 			>
 				<img v-if="src" :src="src" />
 			</div>
@@ -46,7 +48,19 @@
 
 				<TransitionGroup name="fade">
 					<div v-for="ind of indicators" :key="ind.icon" class="state-indicator">
-						<div v-tooltip="ind.tooltip" v-tooltip:position="'right-end'">
+						<div
+							v-if="ind.tooltip === 'Unlisted'"
+							v-tooltip="ind.tooltip"
+							v-tooltip:position="'right-end'"
+							:style="{ cursor: 'pointer' }"
+							class="state-indicator unlisted-indicator"
+							@click="forceUncensor = !forceUncensor"
+						>
+							<div class="icon" :style="{ color: ind.color }">
+								<Icon :icon="ind.icon" />
+							</div>
+						</div>
+						<div v-else v-tooltip="ind.tooltip" v-tooltip:position="'right-end'">
 							<div class="icon" :style="{ color: ind.color }">
 								<Icon :icon="ind.icon" />
 							</div>
@@ -106,6 +120,7 @@ const { namedSets } = storeToRefs(useStore());
 const actor = useActor();
 
 const isUnavailable = ref(false);
+const forceUncensor = ref(false);
 
 const modal = useModal();
 const m = useMutationStore();


### PR DESCRIPTION
QOL feature that allows users to quickly toggle the censoring of an unlisted emote within the emote card by clicking on the respective indicator. 

https://github.com/SevenTV/Website/assets/6964154/b7c65221-6103-44ce-923a-b9b943fa08d4

